### PR TITLE
fix: standardize source files type and remove __unused from types

### DIFF
--- a/packages/core/hooks/ios/extractors/method.ts
+++ b/packages/core/hooks/ios/extractors/method.ts
@@ -22,6 +22,7 @@ export function extractObjcMethodContents(
   const signature = `- (${isSync ? 'id' : 'void'})${contents
     .trim()
     .replace(/\s+/g, ' ') // Standardise all whitespace to a single space
+    .replace(/__unused /g, '') // Remove __unused
     .replace(/\s?\*\s?/g, '*') // Collapse (NSString *) or similar to (NSString*)
     .replace(/\s*:\s*/g, ':')};`;
 


### PR DESCRIPTION
the change to `autolink-info` fixes an issue where if a package specifies a single string as source files, open native would fail to link it

For example:
```
source_files: someFiles/**
```

when doing `[...commonSourceFiles`, the result would be: `['s', 'o', 'm', 'e'....`. So now we standardize the type as always an array of strings.

The change to `method` solves the issue where the type would start with `__unused ` when it was left by the package developer (in this case `@react-native-community/netinfo`)