### PR TITLE
fix(android): gradle 8

### DIFF
--- a/packages/core/hooks/android/getters/autolink-info.ts
+++ b/packages/core/hooks/android/getters/autolink-info.ts
@@ -1,7 +1,7 @@
 import { AndroidDependencyParams, exists, logPrefix } from '../common';
 import * as path from 'path';
 import { getManifestPath } from './manifest-path';
-import { getAndroidPackageName } from './package-name';
+import { getAndroidPackageName, hasNamespace } from './package-name';
 import { extractPackageModules } from '../extractors/modules';
 import { extractLibraryName } from '../extractors/library-name';
 import { extractComponentDescriptors } from '../extractors/component-descriptors';
@@ -77,6 +77,8 @@ export async function getPackageAutolinkInfo({
   const androidPackageName =
     userConfig.packageName ||
     (await getAndroidPackageName(manifestPath, buildGradlePath));
+
+  const namespaceDefined = hasNamespace(buildGradlePath);
   const parsed = await extractPackageModules(sourceDir);
   if (!parsed) {
     return null;
@@ -196,5 +198,11 @@ export async function getPackageAutolinkInfo({
     packageInstance,
     /** @example '/Users/jamie/Documents/git/nativescript-magic-spells/dist/packages/react-native-module-test/android' */
     sourceDir,
+    /** example false */
+    hasNamespace: namespaceDefined,
+    /** @example '/Users/jamie/Documents/git/nativescript-magic-spells/dist/packages/react-native-module-test/android/build.gradle' */
+    buildGradlePath,
+    /** @example 'com.testmodule' */
+    androidPackageName
   };
 }

--- a/packages/core/hooks/android/getters/autolink-info.ts
+++ b/packages/core/hooks/android/getters/autolink-info.ts
@@ -78,7 +78,7 @@ export async function getPackageAutolinkInfo({
     userConfig.packageName ||
     (await getAndroidPackageName(manifestPath, buildGradlePath));
 
-  const namespaceDefined = hasNamespace(buildGradlePath);
+  const namespaceDefined = await hasNamespace(buildGradlePath);
   const parsed = await extractPackageModules(sourceDir);
   if (!parsed) {
     return null;

--- a/packages/core/hooks/android/getters/package-name.ts
+++ b/packages/core/hooks/android/getters/package-name.ts
@@ -39,3 +39,13 @@ export async function getAndroidPackageName(
 export function validateAndroidPackageName(packageName: string) {
   return /^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$/.test(packageName);
 }
+
+
+export async function hasNamespace(
+  buildGradlePath: string
+): Promise<boolean> {
+
+  const buildGradle = readFileSync(buildGradlePath, 'utf8');
+  const packageNameMatchArray = buildGradle.match(/namespace[ |=]"(.+?)"/);
+  return !!(packageNameMatchArray && packageNameMatchArray.length > 0);
+}

--- a/packages/core/hooks/android/writers/write-namespace-gradle.ts
+++ b/packages/core/hooks/android/writers/write-namespace-gradle.ts
@@ -1,0 +1,30 @@
+import { exists, readFile, writeFile } from '../common';
+
+export async function writeNamespaceGradleFile(
+  buildGradlePath: string,
+  packageName: string
+) {
+  const buildGradleNamespacePatch = `// Mark open-native_core namespace patch
+  android {
+  namespace "${packageName}"
+    `;
+  if (!(await exists(buildGradlePath))) return;
+  const currentSettingsGradle = await readFile(buildGradlePath, {
+    encoding: 'utf-8',
+  });
+  if (currentSettingsGradle.includes('Mark open-native_core namespace patch'))
+    return;
+
+  return await writeFile(
+    buildGradlePath,
+    [
+      currentSettingsGradle.replace(
+        /(android\s*\{)/,
+        buildGradleNamespacePatch
+      ),
+    ].join('\n'),
+    {
+      encoding: 'utf-8',
+    }
+  );
+}


### PR DESCRIPTION
Uses the androidPackageName as the namespace if one was not supplied